### PR TITLE
Refactor encoding fixer

### DIFF
--- a/Mp3Tagger/Mp3Tagger/Kernel/Features/EncodingFixer.cs
+++ b/Mp3Tagger/Mp3Tagger/Kernel/Features/EncodingFixer.cs
@@ -29,8 +29,10 @@ namespace Mp3Tagger.Kernel.Features
         {
             FeatureProcessReport progressReport = new FeatureProcessReport
             {
-                TotalOperations = list.Count                
+                TotalOperations = list.Count
             };
+
+            //ToDo:01-05-2018:fonblaser: Consider removing intermediate await of synchronous operation
             await Task.Run(() =>
             {
                 for (var index = 0; index < list.Count; index++)
@@ -39,7 +41,7 @@ namespace Mp3Tagger.Kernel.Features
                     ApplyToComposition(list[index]);
                     progressUpdatedCallback(progressReport);
                 }
-            });            
+            });
         }
 
         public void ApplyToComposition(Composition composition)
@@ -52,18 +54,9 @@ namespace Mp3Tagger.Kernel.Features
             composition.Conductor = ToUtf8(composition.Conductor);
             composition.Copyright = ToUtf8(composition.Copyright);
             composition.Grouping = ToUtf8(composition.Grouping);
-            for (var i = 0; i < composition.AlbumArtists.Length; i++)
-            {
-                composition.AlbumArtists[i] = ToUtf8(composition.AlbumArtists[i]);
-            }
-            for (var i = 0; i < composition.Composers.Length; i++)
-            {
-                composition.Composers[i] = ToUtf8(composition.Composers[i]);
-            }
-            for (var i = 0; i < composition.Genres.Length; i++)
-            {
-                composition.Genres[i] = ToUtf8(composition.Genres[i]);
-            }            
+            composition.AlbumArtists = composition.AlbumArtists.Select(ToUtf8).ToArray();
+            composition.Composers = composition.Composers.Select(ToUtf8).ToArray();
+            composition.Genres = composition.Genres.Select(ToUtf8).ToArray();
         }
 
         private string ToUtf8(string unknown)

--- a/Mp3Tagger/Mp3Tagger/Mp3Tagger.csproj
+++ b/Mp3Tagger/Mp3Tagger/Mp3Tagger.csproj
@@ -38,6 +38,9 @@
     <Reference Include="Microsoft.Windows.Shell, Version=3.0.1.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Windows.Shell.3.0.1.0\lib\net40\Microsoft.Windows.Shell.dll</HintPath>
     </Reference>
+    <Reference Include="policy.2.0.taglib-sharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=db62eba44689b5b0, processorArchitecture=MSIL">
+      <HintPath>..\packages\taglib.2.1.0.0\lib\policy.2.0.taglib-sharp.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Data" />
     <Reference Include="System.Deployment" />
@@ -51,8 +54,8 @@
     <Reference Include="System.Xaml">
       <RequiredTargetFramework>4.0</RequiredTargetFramework>
     </Reference>
-    <Reference Include="taglib-sharp">
-      <HintPath>..\..\..\..\Libraries\taglib-sharp.dll</HintPath>
+    <Reference Include="taglib-sharp, Version=2.1.0.0, Culture=neutral, PublicKeyToken=db62eba44689b5b0, processorArchitecture=MSIL">
+      <HintPath>..\packages\taglib.2.1.0.0\lib\taglib-sharp.dll</HintPath>
     </Reference>
     <Reference Include="WindowsBase" />
     <Reference Include="PresentationCore" />

--- a/Mp3Tagger/Mp3Tagger/packages.config
+++ b/Mp3Tagger/Mp3Tagger/packages.config
@@ -1,4 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.Windows.Shell" version="3.0.1.0" targetFramework="net461" />
+  <package id="taglib" version="2.1.0.0" targetFramework="net461" />
 </packages>


### PR DESCRIPTION
This PR provides the lite-reading changes for the `EncodingFixer` component. Also, the `TagLib` library had been extracted as the NuGet package.